### PR TITLE
Adds a check for port number in IP to country lookup

### DIFF
--- a/Zone.UmbracoPersonalisationGroups/Criteria/Country/HttpContextIpProvider.cs
+++ b/Zone.UmbracoPersonalisationGroups/Criteria/Country/HttpContextIpProvider.cs
@@ -25,11 +25,21 @@
             {
                 if (IsServerVariableForClientIpAvailableAndNotSetToAPrivateIp(httpContext, variable))
                 {
-                    return httpContext.Request.ServerVariables[variable];
+                    return RemovePortNumberFromIp(httpContext.Request.ServerVariables[variable]);
                 }
             }
 
             return string.Empty;
+        }
+
+        private string RemovePortNumberFromIp(string ip)
+        {
+            if (ip.Contains(":"))
+            {
+                ip = ip.Substring(0, ip.IndexOf(":"));
+            }
+
+            return ip;
         }
 
         private IEnumerable<string> GetServerVariablesForPublicIpDetection()


### PR DESCRIPTION
With X-Forwards there's a risk of a port being added to the ip, thus
passing a wrong format to Maxmind