### PR TITLE
Additional Extensions : Custom groups

### DIFF
--- a/Zone.UmbracoPersonalisationGroups/ExtensionMethods/PublishedContentExtensions.cs
+++ b/Zone.UmbracoPersonalisationGroups/ExtensionMethods/PublishedContentExtensions.cs
@@ -13,6 +13,7 @@
     /// </summary>
     public static class PublishedContentExtensions
     {
+
         /// <summary>
         /// Adds an extension method to IPublishedContent to determine if the content item should be shown to the current site
         /// visitor, based on the personalisation groups associated with it.
@@ -23,6 +24,34 @@
         public static bool ShowToVisitor(this IPublishedContent content, bool showIfNoGroupsDefined = true)
         {
             var pickedGroups = GetPickedGroups(content);
+            return ShowToVisitor(pickedGroups, showIfNoGroupsDefined);
+        }
+
+        public static bool ShowToVisitor(this UmbracoHelper umbraco, IEnumerable<int> groupIds, bool showIfNoGroupDefined = true)
+        {
+            try
+            {
+                var pickedGroups = umbraco.TypedContent(groupIds).ToList();
+
+                return ShowToVisitor(pickedGroups, showIfNoGroupDefined);
+            }
+            catch(Exception ex)
+            {
+                throw new Exception(ex.Message);
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Adds an extension method to IPublishedContent to determine if the content item should be shown to the current site
+        /// visitor, based on the personalisation groups associated with it.
+        /// </summary>
+        /// <param name="pickedGroups">List of IPublishedContent items that are the groups you want to check against.</param>
+        /// <param name="showIfNoGroupsDefined">Indicates the response to return if groups cannot be found on the content</param>
+        /// <returns>True if content should be shown to visitor</returns>
+        public static bool ShowToVisitor(IList<IPublishedContent> pickedGroups, bool showIfNoGroupsDefined = true)
+        {
             if (!pickedGroups.Any())
             {
                 // No personalisation groups picked or no property for picker, so we return the provided default


### PR DESCRIPTION
Adding a generic extra extension method, where you can pass in the list of group Ids. 

This involves changing the main extension method to take a list of groups in then creating a stub extension method to maintain the existing functionality, and a new UmbracoHelper Extension method, that takes a list of integer values - and uses them as the personalization group ids. 

Then we can pass in our own set of personalization groups. This enables us to get the groups from other properties, or child items. 

In our specific example, we are using LeBlender to create custom Grid Editors, and adding the Personalization Group Picker to the editor. At render time, we are getting the groups from the value in the editor and passing it to the new generic extension method `Umbraco.ShowToVisitor(groupIds)`. This means we can then have personalized blocks on our grid layout. 