### PR TITLE
Update to handle UDI picker format in Umbraco.Core 7.6+

### DIFF
--- a/Zone.UmbracoPersonalisationGroups/ExtensionMethods/PublishedContentExtensions.cs
+++ b/Zone.UmbracoPersonalisationGroups/ExtensionMethods/PublishedContentExtensions.cs
@@ -152,16 +152,22 @@
             var propertyAlias = GetGroupPickerAlias();
             if (content.HasProperty(propertyAlias))
             {
-                var propertyValue = content.GetProperty(propertyAlias).DataValue.ToString();
-                if (!string.IsNullOrEmpty(propertyValue))
-                {
-                    var pickedGroupIds = propertyValue
-                        .Split(',')
-                        .Select(x => int.Parse(x));
+                var list = content.GetPropertyValue<IEnumerable<IPublishedContent>>(propertyAlias);
 
-                    var umbracoHelper = new UmbracoHelper(UmbracoContext.Current);
-                    return umbracoHelper.TypedContent(pickedGroupIds).ToList();
+                if (list == null)
+                {
+                    var item = content.GetPropertyValue<IPublishedContent>(propertyAlias);
+
+                    if (item == null)
+                    {
+                        return new List<IPublishedContent>();
+                    }
+
+                    return new List<IPublishedContent> { item };
                 }
+
+                return list.ToList();
+
             }
 
             return new List<IPublishedContent>();


### PR DESCRIPTION
I think this'll do it...will be for 7.6+ only so breaks backwards compatibility if that's acceptable.  Else can handle with a new build version or otherwise.

https://github.com/AndyButland/UmbracoPersonalisationGroups/issues/7