### PR TITLE
Add an optional setting to disable the filtering of content

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -138,6 +138,7 @@ If you want to simply check if the current user matches one or more groups by th
 
 No configuration is required if you are happy to accept the default behaviour of the package.  The following optional keys can be added to your web.config appSettings though if required to amend this.  
 
+- `<add key="personalisationGroups.disabled" value="false"/>` - disables the filtering of content by personalisation groups, if this is set to true your content won't differ no matter what is configured in Umbraco
 - `<add key="personalisationGroups.groupPickerAlias" value="myCustomAlias"/>` - amends the alias that must be used when creating a property field of type personalisation group picker
 - `<add key="personalisationGroups.geoLocationCountryDatabasePath" value="/my/custom/relative/path"/>` - amends the convention path for where the IP-country geolocation database can be found see below for more details.
 - `<add key="personalisationGroups.geoLocationCityDatabasePath" value="/my/custom/relative/path"/>` - amends the convention path for where the IP-city geolocation database can be found see below for more details.

--- a/Zone.UmbracoPersonalisationGroups.Tests/Helpers/UmbracoExtensionsHelperTests.cs
+++ b/Zone.UmbracoPersonalisationGroups.Tests/Helpers/UmbracoExtensionsHelperTests.cs
@@ -6,11 +6,33 @@
     using Moq;
     using Umbraco.Core.Models;
     using Zone.UmbracoPersonalisationGroups;
+    using Zone.UmbracoPersonalisationGroups.Configuration;
     using Zone.UmbracoPersonalisationGroups.Helpers;
 
     [TestClass]
     public class UmbracoExtensionsHelperTests
     {
+        [TestInitialize]
+        public void Setup()
+        {
+            // this is needed to ensure that Config.Setup is OK in each test
+            UmbracoConfigExtensions.ResetConfig();
+        }
+
+        [TestMethod]
+        public void MatchGroups_WithPackageDisabled_ReturnsTrue()
+        {
+            // Arrange
+            var pickedGroups = new List<IPublishedContent>();
+            PersonalisationGroupsConfig.Setup(new PersonalisationGroupsConfig(disablePackage: true));
+
+            // Act
+            var result = UmbracoExtensionsHelper.MatchGroups(pickedGroups);
+
+            // Assert
+            Assert.IsTrue(result);
+        }
+
         [TestMethod]
         public void MatchGroups_WithNoGroups_ReturnsFalse()
         {
@@ -149,6 +171,36 @@
         }
 
         [TestMethod]
+        public void MatchGroupsByName_WithPackageDisabledUsingAll_ReturnsTrue()
+        {
+            // Arrange
+            var groups = new string[] { "Group 1000", "Group X" };
+            var pickedGroups = new List<IPublishedContent>();
+            PersonalisationGroupsConfig.Setup(new PersonalisationGroupsConfig(disablePackage: true));
+
+            // Act
+            var result = UmbracoExtensionsHelper.MatchGroupsByName(groups, pickedGroups, PersonalisationGroupDefinitionMatch.All);
+
+            // Assert
+            Assert.IsTrue(result);
+        }
+
+        [TestMethod]
+        public void MatchGroupsByName_WithPackageDisabledUsingAny_ReturnsTrue()
+        {
+            // Arrange
+            var groups = new string[] { "Group 1000", "Group X" };
+            var pickedGroups = new List<IPublishedContent>();
+            PersonalisationGroupsConfig.Setup(new PersonalisationGroupsConfig(disablePackage: true));
+
+            // Act
+            var result = UmbracoExtensionsHelper.MatchGroupsByName(groups, pickedGroups, PersonalisationGroupDefinitionMatch.Any);
+
+            // Assert
+            Assert.IsTrue(result);
+        }
+
+        [TestMethod]
         public void MatchGroupsByName_WithNonMatchingGroupsUsingAll_ReturnsFalse()
         {
             // Arrange
@@ -259,6 +311,20 @@
 
             // Assert
             Assert.IsTrue(result);
+        }
+
+        [TestMethod]
+        public void ScoreGroups_WithPackageDisabled_ReturnsDefaultScore()
+        {
+            // Arrange
+            var pickedGroups = new List<IPublishedContent>();
+            PersonalisationGroupsConfig.Setup(new PersonalisationGroupsConfig(disablePackage: true));
+
+            // Act
+            var result = UmbracoExtensionsHelper.ScoreGroups(pickedGroups);
+
+            // Assert
+            Assert.AreEqual(0, result);
         }
 
         [TestMethod]

--- a/Zone.UmbracoPersonalisationGroups/AppConstants.cs
+++ b/Zone.UmbracoPersonalisationGroups/AppConstants.cs
@@ -12,33 +12,37 @@
     {
         public static class ConfigKeys
         {
-            public const string CustomPersonalisationGroupPickerAlias = "personalisationGroups.groupPickerAlias";
+            private const string Prefix = "personalisationGroups.";
 
-            public const string CustomGeoLocationCountryDatabasePath = "personalisationGroups.geoLocationCountryDatabasePath";
+            public const string DisablePackage = Prefix + "disabled";
 
-            public const string CustomGeoLocationCityDatabasePath = "personalisationGroups.geoLocationCityDatabasePath";
+            public const string CustomPersonalisationGroupPickerAlias = Prefix + "groupPickerAlias";
 
-            public const string IncludeCriteria = "personalisationGroups.includeCriteria";
+            public const string CustomGeoLocationCountryDatabasePath = Prefix + "geoLocationCountryDatabasePath";
 
-            public const string ExcludeCriteria = "personalisationGroups.excludeCriteria";
+            public const string CustomGeoLocationCityDatabasePath = Prefix + "geoLocationCityDatabasePath";
 
-            public const string NumberOfVisitsTrackingCookieExpiryInDays = "personalisationGroups.numberOfVisitsTrackingCookieExpiryInDays";
+            public const string IncludeCriteria = Prefix + "includeCriteria";
 
-            public const string ViewedPagesTrackingCookieExpiryInDays = "personalisationGroups.viewedPagesTrackingCookieExpiryInDays";
+            public const string ExcludeCriteria = Prefix + "excludeCriteria";
 
-            public const string CookieKeyForTrackingNumberOfVisits = "personalisationGroups.CookieKeyForTrackingNumberOfVisits";
+            public const string NumberOfVisitsTrackingCookieExpiryInDays = Prefix + "numberOfVisitsTrackingCookieExpiryInDays";
 
-            public const string CookieKeyForTrackingIfSessionAlreadyTracked = "personalisationGroups.cookieKeyForTrackingIfSessionAlreadyTracked";
+            public const string ViewedPagesTrackingCookieExpiryInDays = Prefix + "viewedPagesTrackingCookieExpiryInDays";
 
-            public const string CookieKeyForTrackingPagesViewed = "personalisationGroups.CookieKeyForTrackingPagesViewed";
+            public const string CookieKeyForTrackingNumberOfVisits = Prefix + "CookieKeyForTrackingNumberOfVisits";
 
-            public const string CookieKeyForSessionMatchedGroups = "personalisationGroups.cookieKeyForSessionMatchedGroups";
+            public const string CookieKeyForTrackingIfSessionAlreadyTracked = Prefix + "cookieKeyForTrackingIfSessionAlreadyTracked";
 
-            public const string CookieKeyForPersistentMatchedGroups = "personalisationGroups.cookieKeyForPersistentMatchedGroups";
+            public const string CookieKeyForTrackingPagesViewed = Prefix + "CookieKeyForTrackingPagesViewed";
 
-            public const string PersistentMatchedGroupsCookieExpiryInDays = "personalisationGroups.persistentMatchedGroupsCookieExpiryInDays";
+            public const string CookieKeyForSessionMatchedGroups = Prefix + "cookieKeyForSessionMatchedGroups";
 
-            public const string TestFixedIp = "personalisationGroups.testFixedIp";
+            public const string CookieKeyForPersistentMatchedGroups = Prefix + "cookieKeyForPersistentMatchedGroups";
+
+            public const string PersistentMatchedGroupsCookieExpiryInDays = Prefix + "persistentMatchedGroupsCookieExpiryInDays";
+
+            public const string TestFixedIp = Prefix + "testFixedIp";
         }
 
         public static class DocumentTypeAliases

--- a/Zone.UmbracoPersonalisationGroups/Configuration/PersonalisationGroupsConfig.cs
+++ b/Zone.UmbracoPersonalisationGroups/Configuration/PersonalisationGroupsConfig.cs
@@ -1,0 +1,40 @@
+﻿namespace Zone.UmbracoPersonalisationGroups.Configuration
+{
+    using System.Configuration;
+
+    /// <summary>
+    /// Configuration for personalisation groups
+    /// </summary>
+    public class PersonalisationGroupsConfig
+    {
+        private static PersonalisationGroupsConfig _value;
+
+        internal static PersonalisationGroupsConfig Value => _value ?? new PersonalisationGroupsConfig();
+
+        public static void Setup(PersonalisationGroupsConfig config)
+        {
+            _value = config;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PersonalisationGroupsConfig"/> class.
+        /// </summary>
+        private PersonalisationGroupsConfig()
+        {
+            DisablePackage = ConfigurationManager.AppSettings[AppConstants.ConfigKeys.DisablePackage] == "true";
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PersonalisationGroupsConfig"/> class.
+        /// </summary>
+        public PersonalisationGroupsConfig(bool disablePackage = false)
+        {
+            DisablePackage = disablePackage;
+        }
+
+        /// <summary>
+        /// Disables matching of content
+        /// </summary>
+        public bool DisablePackage { get; }
+    }
+}

--- a/Zone.UmbracoPersonalisationGroups/Configuration/UmbracoConfigExtensions.cs
+++ b/Zone.UmbracoPersonalisationGroups/Configuration/UmbracoConfigExtensions.cs
@@ -1,0 +1,34 @@
+﻿namespace Zone.UmbracoPersonalisationGroups.Configuration
+{
+    using System.Threading;
+    using Umbraco.Core.Configuration;
+
+    /// <summary>
+    /// Provides extension methods for the <see cref="UmbracoConfig"/> class.
+    /// </summary>
+    public static class UmbracoConfigExtensions
+    {
+        private static PersonalisationGroupsConfig _config;
+
+        /// <summary>
+        /// Gets configuration for personalisation groups.
+        /// </summary>
+        /// <param name="umbracoConfig">The umbraco configuration.</param>
+        /// <returns>The personalisation groups configuration.</returns>
+        /// <remarks> 
+        /// Getting the personalisation groups configuration freezes its state, and 
+        /// any attempt at modifying the configuration will be ignored. 
+        /// </remarks>
+        public static PersonalisationGroupsConfig PersonalisationGroups(this UmbracoConfig umbracoConfig)
+        {
+            LazyInitializer.EnsureInitialized(ref _config, () => PersonalisationGroupsConfig.Value);
+            return _config;
+        }
+
+        // internal for tests
+        internal static void ResetConfig()
+        {
+            _config = null;
+        }
+    }
+}

--- a/Zone.UmbracoPersonalisationGroups/ExtensionMethods/UmbracoExtensionsHelper.cs
+++ b/Zone.UmbracoPersonalisationGroups/ExtensionMethods/UmbracoExtensionsHelper.cs
@@ -5,18 +5,32 @@
     using System.Configuration;
     using System.Linq;
     using System.Web;
+    using Umbraco.Core.Configuration;
     using Umbraco.Core.Models;
     using Umbraco.Web;
+    using Zone.UmbracoPersonalisationGroups.Configuration;
 
     internal static class UmbracoExtensionsHelper
     {
         internal static bool MatchGroup(IPublishedContent pickedGroup)
         {
+            // package is disabled, return default
+            if (UmbracoConfig.For.PersonalisationGroups().DisablePackage)
+            {
+                return true;
+            }
+
             return MatchGroups(new List<IPublishedContent> { pickedGroup });
         }
 
         internal static bool MatchGroups(IList<IPublishedContent> pickedGroups)
         {
+            // package is disabled, return default
+            if (UmbracoConfig.For.PersonalisationGroups().DisablePackage)
+            {
+                return true;
+            }
+
             // Check each personalisation group assigned for a match with the current site visitor
             foreach (var group in pickedGroups)
             {
@@ -44,6 +58,12 @@
 
         internal static bool MatchGroupsByName(string[] groupNames, IList<IPublishedContent> groups, PersonalisationGroupDefinitionMatch matchType)
         {
+            // package is disabled, return default
+            if (UmbracoConfig.For.PersonalisationGroups().DisablePackage)
+            {
+                return true;
+            }
+
             var matches = 0;
             foreach (var groupName in groupNames)
             {
@@ -77,6 +97,12 @@
 
         internal static int ScoreGroups(IList<IPublishedContent> pickedGroups)
         {
+            // package is disabled, return default
+            if (UmbracoConfig.For.PersonalisationGroups().DisablePackage)
+            {
+                return 0;
+            }
+
             // Check each personalisation group assigned for a match with the current site visitor
             var score = 0;
             foreach (var group in pickedGroups)

--- a/Zone.UmbracoPersonalisationGroups/Zone.UmbracoPersonalisationGroups.csproj
+++ b/Zone.UmbracoPersonalisationGroups/Zone.UmbracoPersonalisationGroups.csproj
@@ -203,6 +203,8 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Configuration\UmbracoConfigExtensions.cs" />
+    <Compile Include="Configuration\PersonalisationGroupsConfig.cs" />
     <Compile Include="AppConstants.cs" />
     <Compile Include="Controllers\BaseJsonResultController.cs" />
     <Compile Include="Controllers\GeoLocationController.cs" />


### PR DESCRIPTION
Hey Andy,

As discussed, this provides a way to disable the filtering of content if you have the package installed but want to turn it off for whatever reason.

It simply returns the defaults for all the key methods that would do the matching. i.e. all content should be shown. 

It's worth mentioning that I've not amended anything that happens in terms of the editor experience so you'll see the same options in Umbraco. Probably would be a good idea to switch out the picker to show a warning to the editor that the package is currently disabled. Not sure how you want to proceed on that one.