### PR TITLE
added namespace to route map

### DIFF
--- a/Zone.UmbracoPersonalisationGroups.Common/Routing/RouteConfig.cs
+++ b/Zone.UmbracoPersonalisationGroups.Common/Routing/RouteConfig.cs
@@ -30,7 +30,7 @@
             routes.MapRoute(
                 name: "Member methods",
                 url: "App_Plugins/UmbracoPersonalisationGroups/Member/{action}",
-                defaults: new { controller = "Member", action = "Index" });
+                defaults: new { controller = "Member", action = "Index" }, new[] { "Zone.UmbracoPersonalisationGroups.Controllers" });
 
             routes.MapRoute(
                 name: "Geo location methods",


### PR DESCRIPTION
Hi Andy.

I have been playing around with v7 of personalisation groups and found an issue with a Controller name clash between this package and our own code (both had a 'MemberController'). 

This PR fixes the specific issue i had by specifically name-spacing the Route Map for Member Controller. I notice there are other Routes in this config and it might be worth name spacing those too, however i wasn't sure what the best values for those namespaces would be.

Hope this makes sense, happy to discuss.

Cheers
Lachlann

