### PR TITLE
Check frontendrequest in trackpageview function

### DIFF
--- a/Zone.UmbracoPersonalisationGroups/Criteria/PagesViewed/UserActivityTracker.cs
+++ b/Zone.UmbracoPersonalisationGroups/Criteria/PagesViewed/UserActivityTracker.cs
@@ -8,6 +8,11 @@ namespace Zone.UmbracoPersonalisationGroups.Criteria.PagesViewed
         public static void TrackPageView(object sender, EventArgs e)
         {
             var umbracoContext = UmbracoContext.Current;
+            var isFrontEndRequest = umbracoContext?.IsFrontEndUmbracoRequest ?? false;
+            if (!isFrontEndRequest)
+            {
+                return;
+            }
             var pageId = umbracoContext?.PageId;
 
             if (pageId == null)


### PR DESCRIPTION
As per issue 25, https://github.com/AndyButland/UmbracoPersonalisationGroups/issues/25, when a macro is rendered in the backoffice an error is thrown as the cookies are trying to be set. Don't believe that backoffice users need to be tracked so have disabled this function.